### PR TITLE
fix: use environment instead of stack name in uuid linking material

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export class EncryptedSecret extends Construct {
     // Create the Lambda Function to decrypt the ciphertext and store the value in the Secret
     const decryptSecretFunction = new SingletonFunction(this, 'DecryptSecretFunction', {
       lambdaPurpose: 'DecryptSecret',
-      uuid: crypto.createHash('md5').update(Stack.of(this).stackName).digest('hex'),
+      uuid: crypto.createHash('md5').update(Stack.of(this).environment).digest('hex'),
       runtime: Runtime.NODEJS_22_X,
       architecture: Architecture.ARM_64,
       code: Code.fromAsset(path.join(__dirname, 'lambda')),


### PR DESCRIPTION
- allows it to be a true singleton in the app
- allows it to not cause stack change thrash if used in a nested stack where the stackname is derived a bit randomly within the stack

Fixes #90 