### PR TITLE
fix: set installLatestAwsSdk to false on AwsCustomResource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ export class EncryptedSecret extends Construct {
 
     // Create the custom resource
     const lambdaInvokeAwsCustomResource = new AwsCustomResource(this, 'CustomResourceSecretLambdaInvoke', {
+      installLatestAwsSdk: false,
       onCreate: {
         service: 'Lambda',
         action: 'invoke',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -86,6 +86,19 @@ it('Fails when cipherText is not provided', () => {
   }).toThrow(Error);
 });
 
+it('sets installLatestAwsSdk to false on the custom resource', () => {
+  // WHEN
+  new EncryptedSecret(stack, 'MyConstruct', {
+    ciphertextBlob: 'foobar',
+    keyId: 'arn:aws:kms:us-west-2:012345678901:key/483291fd-92ad-4dde-af8b-e4203b013258',
+  });
+
+  // THEN
+  Template.fromStack(stack).hasResourceProperties('Custom::AWS', {
+    InstallLatestAwsSdk: false,
+  });
+});
+
 it('create a EncryptedSecret with minimal required properties', () => {
   // WHEN
   new EncryptedSecret(stack, 'MyConstruct', {


### PR DESCRIPTION
## Summary

- The `AwsCustomResource` used internally to invoke the decrypt Lambda does not explicitly set `installLatestAwsSdk`, which causes CDK to emit the `@aws-cdk/custom-resources:installLatestAwsSdkNotSpecified` warning during synth
- Modern Lambda runtimes (Node 18+) already ship with AWS SDK v3, so bundling it at deploy time adds unnecessary overhead
- Sets `installLatestAwsSdk: false` on the `AwsCustomResource` to suppress the warning and skip the unnecessary SDK install

## Test plan

- [x] Added test asserting `InstallLatestAwsSdk: false` is present on the `Custom::AWS` resource
- [x] All existing tests pass (13/13)
- [x] 100% code coverage maintained